### PR TITLE
Add app ID as an optional setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ _Note: Running the test suite with `pytest -v tests/` requires both
 slash_info = True
 # Allow expansion of inline references like `u/RandomRedditor` or `r/eyebleach`
 # (links are always expanded)
+
+app_id = abcdef0123456789
+# Optional custom app ID for the reddit API
 ```
+
+The `app_id` setting is provided mostly for future-proofing after [API policy
+changes announced by Reddit Inc. in April
+2023](https://old.reddit.com/r/reddit/comments/12qwagm/an_update_regarding_reddits_api/).
+It exists so possible future API limitations can be worked around by users
+without requiring a package update. **As of the time this package version was
+published, the `app_id` setting _does not_ need to have a value.**
 
 
 ## Special thanks

--- a/sopel_reddit/__init__.py
+++ b/sopel_reddit/__init__.py
@@ -44,17 +44,21 @@ class RedditSection(types.StaticSection):
     slash_info = types.BooleanAttribute('slash_info', True)
     """Expand inline references to users (u/someone) and subreddits (r/subname) in chat."""
 
+    app_id = types.ValidatedAttribute('app_id', default='6EiphT6SSQq7FQ')
+    """Optional custom app ID for the reddit API."""
+
 
 def setup(bot):
+    bot.config.define_section('reddit', RedditSection)
+
     if 'reddit_praw' not in bot.memory:
         # Create a PRAW instance just once, at load time
         bot.memory['reddit_praw'] = praw.Reddit(
             user_agent=USER_AGENT,
-            client_id='6EiphT6SSQq7FQ',
+            client_id=bot.settings.reddit.app_id,
             client_secret=None,
             check_for_updates=False,
         )
-    bot.config.define_section('reddit', RedditSection)
 
 
 def configure(config):


### PR DESCRIPTION
This is for future-proofing. See readme changes for the reasoning; in short, it's possible that changes to reddit's API policies will affect the usefulness of this plugin's shared OAuth app ID in the long term.