### PR TITLE
Improved test coverage

### DIFF
--- a/sopel_reddit/__init__.py
+++ b/sopel_reddit/__init__.py
@@ -26,7 +26,7 @@ from sopel.tools.web import USER_AGENT
 
 PLUGIN_OUTPUT_PREFIX = '[reddit] '
 
-domain = r'https?://(?:www\.|old\.|new\.|pay\.|ssl\.|[a-z]{2}\.)?reddit\.com'
+domain = r'https?://(?:www\.|old\.|new\.|beta\.|pay\.|ssl\.|[a-z]{2}\.)?reddit\.com'
 subreddit_url = r'%s/r/([\w-]+)/?$' % domain
 post_or_comment_url = (
     domain +


### PR DESCRIPTION
By the power of multiple `parametrize` marks, we can get full coverage of with/without trailing slash, with/without query string, and any fixed subdomain (plus a sampling of the language-based ones).

Same line count as the previous, manually-curated list of test cases, but MUCH more comprehensive (over 700 cases now, vs. the original 30).