### PR TITLE
Revamp subreddit output to show title and/or public description

### DIFF
--- a/sopel_reddit/__init__.py
+++ b/sopel_reddit/__init__.py
@@ -314,7 +314,7 @@ def subreddit_info(bot, trigger, match, commanded=False, explicit_command=False)
             bot.reply("r/" + match + " appears to be a banned subreddit!")
         return plugin.NOLIMIT
 
-    link = 'https://reddit.com/r/' + s.display_name.lower()
+    link = 'https://reddit.com' + s.url
 
     created = get_time_created(bot, trigger, s.created_utc)
 

--- a/sopel_reddit/__init__.py
+++ b/sopel_reddit/__init__.py
@@ -318,8 +318,8 @@ def subreddit_info(bot, trigger, match, commanded=False, explicit_command=False)
 
     created = get_time_created(bot, trigger, s.created_utc)
 
-    message = ('r/{name}{nsfw}{link} | {subscribers} subscribers | '
-               'Created at {created} | {public_description}')
+    message = ('{name}{nsfw}{link} | {subscribers} subscribers | '
+               'Created at {created} | {descriptions}')
 
     nsfw = ''
     if s.over18:
@@ -333,13 +333,15 @@ def subreddit_info(bot, trigger, match, commanded=False, explicit_command=False)
                 'Linking to NSFW content in a SFW channel.'
             )
 
+    descriptions = (text for text in (s.title, s.public_description) if text)
+
     message = message.format(
-        name=s.display_name,
+        name=s.display_name_prefixed,
         nsfw=nsfw,
         link=(' | ' + link) if commanded else '',
         subscribers='{:,}'.format(s.subscribers),
         created=created,
-        public_description=s.public_description,
+        descriptions=' | '.join(descriptions) or '(no description)',
     )
 
     bot.say(message, truncation=' […]')


### PR DESCRIPTION
Some subs define a public description; some don't.

Some subs define a "title"; some don't.

There's also a description shown in the sidebar after joining, but that one can contain Markdown and would be a lot messier to show on IRC. The public description is what's shown in search results.

Bonus: Reverses regression from #9 that made subreddit URL output always lowercase instead of matching the canonical capitalization (to which Reddit will redirect anyway, so just start there to skip an HTTP roundtrip).